### PR TITLE
fix: 适配0.77，在RN侧定义组件属性时需要继承ViewProps

### DIFF
--- a/src/SpinKitNativeComponents.ts
+++ b/src/SpinKitNativeComponents.ts
@@ -1,10 +1,10 @@
 import {
-  HostComponent
+  HostComponent, ViewProps
 } from "react-native";
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { Int32, WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 
-export type SpinnerProps = {
+export interface SpinnerProps extends ViewProps {
   color?: WithDefault<string, '#000000'>;
   size?: WithDefault<Int32, 37>;
   type?: WithDefault<'CircleFlip'


### PR DESCRIPTION
# Summary

- 适配0.77，在RN侧定义组件属性时需要继承ViewProps


## Test Plan

<img width="421" height="903" alt="image" src="https://github.com/user-attachments/assets/92d92eb7-9047-4838-aac9-f3b2dc0cc843" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

